### PR TITLE
ci: switch from MySQL to SQLite for testing

### DIFF
--- a/.github/workflows/tests-on-master.yml
+++ b/.github/workflows/tests-on-master.yml
@@ -7,27 +7,16 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_DATABASE: test_db
-          MYSQL_USER: root
-          MYSQL_PASSWORD: root
-          MYSQL_ROOT_PASSWORD: root
-        ports: ['3306:3306']
-        options: --health-cmd="mysqladmin ping -h localhost" --health-interval=5s --health-timeout=5s --health-retries=5
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          extensions: pdo_mysql, mbstring
+          extensions: sqlite
 
       - name: Install dependencies
-        run: composer install
+        run: composer install --no-progress --prefer-dist
 
       - name: Configure Laravel
         run: |

--- a/app/Jobs/Core/Bank/ImportBankMouvement.php
+++ b/app/Jobs/Core/Bank/ImportBankMouvement.php
@@ -36,7 +36,7 @@ final class ImportBankMouvement implements ShouldQueue
     {
         Log::info('Info Bank', ['Bank' => $this->bank, 'Accounts' => $this->bank->accounts]);
         foreach ($this->bank->accounts as $account) {
-            //$account is object
+            // $account is object
             $transactions = $this->api->get('aggregation/transactions?limit=500&account_id='.$account->account_id.'&min_date=2025-01-01', null, $this->token);
 
             foreach ($transactions['resources'] as $transaction) {


### PR DESCRIPTION
Simplify test setup by replacing MySQL service with SQLite extension. Also optimize composer install command with --no-progress and --prefer-dist flags.