### PR TITLE
ci: update test environment to use MySQL instead of SQLite

### DIFF
--- a/.env.github
+++ b/.env.github
@@ -1,9 +1,9 @@
 APP_ENV=testing
 APP_KEY=base64:x
 APP_DEBUG=true
-DB_CONNECTION=sqlite
-DB_HOST=127.0.0.1
+DB_CONNECTION=mysql
+DB_HOST=mysql
 DB_PORT=3306
-DB_DATABASE=:memory:
+DB_DATABASE=test
 DB_USERNAME=root
-DB_PASSWORD=root
+DB_PASSWORD=password

--- a/.github/workflows/tests-on-master.yml
+++ b/.github/workflows/tests-on-master.yml
@@ -6,6 +6,18 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    container:
+      image: kirschbaumdevelopment/laravel-test-runner:8.3
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: test
+        ports:
+          - 33306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - uses: actions/checkout@v4
@@ -13,7 +25,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          extensions: sqlite
+          extensions: pdo_mysql, mbstring
 
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist


### PR DESCRIPTION
Switch database configuration from SQLite to MySQL in test environment to better match production setup. Update GitHub Actions workflow to include MySQL service container and required PHP extensions.