### PR TITLE
ci(release): add required permissions for semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     branches:
       - production
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   release:
     name: Run semantic-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add necessary permissions for semantic-release to publish GitHub releases, comment on issues/PRs, and use OIDC for npm provenance