### PR TITLE
ci: update deployment scripts to use production branch and latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install: vendor/autoload.php .env public/storage public/build/manifest.json
 	php artisan up
 
 update-start:
-	ssh o2switch "cd /home/mapu6796/admin.c2me.ovh && git reset --hard && git pull origin master && make update"
+	ssh o2switch "cd /home/mapu6796/admin.c2me.ovh && git reset --hard && git pull origin production && make update"
 
 update:
 	bash update.sh

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,6 @@
-php artisan updater:update
+git fetch --tags
+LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+git checkout tags/$LATEST_TAG -b release
+git pull origin release
 
-sed -i "s/^BUGSNAG_API_KEY=\".*\"/BUGSNAG_API_KEY=f75b3bf691ff27f2d77053c946fef9fe/" .env
+sed -i "s/^BUGSNAG_API_KEY=.*/BUGSNAG_API_KEY=f75b3bf691ff27f2d77053c946fef9fe/" .env


### PR DESCRIPTION
Switch git pull target from master to production branch in Makefile Modify update.sh to fetch latest tag and checkout release branch