### PR TITLE
ci(github): improve test failure issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -12,6 +12,6 @@ ${{ process.env.TEST_RESULTS }}
 - [ ] Analyser les changements récents
 
 **Assignation automatique** :
-@tech-lead @devops`,
+@tech-lead @devops,
 labels: ['bug', 'ci'],
 assignees: ['tech-lead', 'vortechstudio']

--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -1,0 +1,17 @@
+## Echec de Test sur la branche ${{ github.branch.name }}
+### Context
+- Workflow: ${{ github.workflow }}
+- Commit: ${{ github.sha }}
+
+### Résultat des tests
+${{ process.env.TEST_RESULTS }}
+
+### Checklist
+- [ ] Vérifier les logs du workflow
+- [ ] Reproduire localement
+- [ ] Analyser les changements récents
+
+**Assignation automatique** :
+@tech-lead @devops`,
+labels: ['bug', 'ci'],
+assignees: ['tech-lead', 'vortechstudio']

--- a/.github/workflows/tests-on-master.yml
+++ b/.github/workflows/tests-on-master.yml
@@ -46,38 +46,13 @@ jobs:
       - name: Run tests
         run: php artisan test --parallel
 
-      - name: Création ticket GitHub
+      - name: Create Issue on Failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: peter-evans/create-issue-from-file@v4
         with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: '[CI] Échec des tests sur main - ' + new Date().toISOString(),
-              body: `### Échec des tests sur la branche main
-
-      **Contexte** :
-      - Workflow: ${{ github.workflow }}
-      - Commit: ${{ github.sha }}
-
-      **Résultats des tests** :
-      \\`\\`\\`
-      ${{ env.TEST_RESULTS }}
-      \\`\\`\\`
-
-      **Checklist investigation** :
-      \\`\\`\\`
-      [x] Vérifier les logs du workflow
-      [x] Reproduire localement
-      [ ] Analyser les changements récents
-      \\`\\`\\`
-
-      **Assignation automatique** :
-      @tech-lead @devops`,
-              labels: ['bug', 'ci'],
-              assignees: ['tech-lead']
-            })
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEST_RESULTS: ${{ steps.run-tests.outputs.error }}
+          title: "🚨 CI Failed on ${{ github.workflow }} (#${{ github.run_number }})"
+          content-filepath: .github/ISSUE_TEMPLATE/ci-failure.md
+          labels: |
+            bug
+            CI
+          assignees: vortechstudio

--- a/.github/workflows/tests-on-master.yml
+++ b/.github/workflows/tests-on-master.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure()
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: "🚨 CI Failed on ${{ github.workflow }} (#${{ github.run_number }})"
           content-filepath: .github/ISSUE_TEMPLATE/ci-failure.md
@@ -56,3 +56,4 @@ jobs:
             bug
             CI
           assignees: vortechstudio
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Refactor the GitHub workflow to use a template file for CI failure issues instead of inline script. This makes the issue creation more maintainable and consistent by:
- Using a dedicated template file
- Simplifying the workflow configuration
- Standardizing issue format and assignments